### PR TITLE
initialize cosign trust root after install

### DIFF
--- a/.github/workflows/bake.yml
+++ b/.github/workflows/bake.yml
@@ -208,6 +208,7 @@ jobs:
 
             const cosign = new Cosign();
             await cosign.printVersion();
+            await exec.exec(cosign.binPath, ['initialize']);
       -
         name: Check dependencies signatures
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
@@ -731,6 +732,7 @@ jobs:
             
             const cosign = new Cosign();
             await cosign.printVersion();
+            await exec.exec(cosign.binPath, ['initialize']);
             
             const containerName = `${Buildx.containerNamePrefix}${inpBuilderName}0`;
             

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -212,6 +212,7 @@ jobs:
 
             const cosign = new Cosign();
             await cosign.printVersion();
+            await exec.exec(cosign.binPath, ['initialize']);
       -
         name: Check dependencies signatures
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
@@ -622,6 +623,7 @@ jobs:
 
             const cosign = new Cosign();
             await cosign.printVersion();
+            await exec.exec(cosign.binPath, ['initialize']);
             
             const containerName = `${Buildx.containerNamePrefix}${inpBuilderName}0`;
             

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -78,6 +78,7 @@ jobs:
 
             const cosign = new Cosign();
             await cosign.printVersion();
+            await exec.exec(cosign.binPath, ['initialize']);
       -
         name: Login to registry
         if: ${{ steps.vars.outputs.signed == 'true' && steps.vars.outputs.output-type == 'image' }}


### PR DESCRIPTION
* closes https://github.com/docker/actions-toolkit/pull/1125
* closes https://github.com/docker/actions-toolkit/pull/1133

This initializes Cosign's Sigstore trust root immediately after Cosign is installed.

Each existing Cosign install step now runs `cosign initialize` through the installed Cosign binary before later signing or verification commands run in that job.

This takes a smaller workflow-level approach than https://github.com/docker/actions-toolkit/pull/1125 and https://github.com/docker/actions-toolkit/pull/1133, which tried to pin or thread an explicit trusted root path through `actions-toolkit`. Those approaches are useful if we need a fully explicit or offline trusted-root artifact, but this failure is caused by Cosign using `--new-bundle-format` before its normal trust-root cache has been initialized. Since each job installs and uses Cosign in the same runner environment, initializing Cosign after install lets Cosign populate its own TUF cache and keeps the fix local to these workflows.