### PR TITLE
bake: pass variables explicitly to buildx

### DIFF
--- a/.github/workflows/.test-bake.yml
+++ b/.github/workflows/.test-bake.yml
@@ -474,13 +474,13 @@ jobs:
       artifact-upload: false
       context: test
       output: local
-      target: secret
+      target: foosec
     secrets:
       build-secrets: |
         fixture_plain: |
           alpha-line
           beta-line
-        secret.fixture_json: ${{ toJSON(format('gamma-line{0}delta-line{0}', fromJSON('"\n"'))) }}
+        foosec.fixture_json: ${{ toJSON(format('gamma-line{0}delta-line{0}', fromJSON('"\n"'))) }}
 
   bake-set-runner:
     uses: ./.github/workflows/bake.yml

--- a/.github/workflows/.test-bake.yml
+++ b/.github/workflows/.test-bake.yml
@@ -582,11 +582,10 @@ jobs:
       contents: read
       id-token: write
     with:
-      setup-qemu: true
       artifact-upload: false
       context: test
       output: local
-      target: go
+      target: vars
       vars: |
         XX_VERSION=1.9.0
 

--- a/.github/workflows/.test-bake.yml
+++ b/.github/workflows/.test-bake.yml
@@ -465,6 +465,23 @@ jobs:
             const builderOutputs = JSON.parse(core.getInput('builder-outputs'));
             core.info(JSON.stringify(builderOutputs, null, 2));
 
+  bake-secret:
+    uses: ./.github/workflows/bake.yml
+    permissions:
+      contents: read
+      id-token: write
+    with:
+      artifact-upload: false
+      context: test
+      output: local
+      target: secret
+    secrets:
+      build-secrets: |
+        fixture_plain: |
+          alpha-line
+          beta-line
+        secret.fixture_json: ${{ toJSON(format('gamma-line{0}delta-line{0}', fromJSON('"\n"'))) }}
+
   bake-set-runner:
     uses: ./.github/workflows/bake.yml
     permissions:

--- a/.github/workflows/.test-build.yml
+++ b/.github/workflows/.test-build.yml
@@ -512,6 +512,22 @@ jobs:
             const builderOutputs = JSON.parse(core.getInput('builder-outputs'));
             core.info(JSON.stringify(builderOutputs, null, 2));
 
+  build-secret:
+    uses: ./.github/workflows/build.yml
+    permissions:
+      contents: read
+      id-token: write
+    with:
+      artifact-upload: false
+      file: test/secret.Dockerfile
+      output: local
+    secrets:
+      build-secrets: |
+        fixture_plain: |
+          alpha-line
+          beta-line
+        fixture_json: ${{ toJSON(format('gamma-line{0}delta-line{0}', fromJSON('"\n"'))) }}
+
   build-set-runner:
     uses: ./.github/workflows/build.yml
     permissions:

--- a/.github/workflows/bake.yml
+++ b/.github/workflows/bake.yml
@@ -212,6 +212,7 @@ jobs:
       metaImages: ${{ steps.set.outputs.metaImages }}
       sign: ${{ steps.set.outputs.sign }}
       privateRepo: ${{ steps.set.outputs.privateRepo }}
+      secretIds: ${{ steps.set.outputs.secretIds }}
       ghaCacheSign: ${{ steps.set.outputs.ghaCacheSign }}
     steps:
       -
@@ -522,6 +523,16 @@ jobs:
                   const match = value.match(/^target:(.+)$/);
                   return match ? match[1] : undefined;
                 };
+                const parseSecretId = secret => {
+                  if (typeof secret === 'string') {
+                    const idAttr = secret.split(',').map(attr => attr.trim()).find(attr => attr.startsWith('id='));
+                    return idAttr ? idAttr.substring(3) : undefined;
+                  }
+                  if (secret && typeof secret === 'object' && typeof secret.id === 'string') {
+                    return secret.id;
+                  }
+                  return undefined;
+                };
                 const resolveTarget = () => {
                   if (targetDefs[inpTarget]) {
                     return inpTarget;
@@ -550,6 +561,11 @@ jobs:
                 if (unsupportedTargets.length > 0) {
                   throw new Error(`Only one target can be built at once, found unsupported targets: ${unsupportedTargets.join(', ')}`);
                 }
+                const secretIds = {};
+                for (const name of allowedTargets) {
+                  secretIds[name] = (targetDefs[name]?.secret || []).map(parseSecretId).filter(Boolean);
+                }
+                core.setOutput('secretIds', JSON.stringify(secretIds));
               });
             } catch (error) {
               core.setFailed(error);
@@ -836,6 +852,7 @@ jobs:
           INPUT_CACHE-SCOPE: ${{ inputs.cache-scope }}
           INPUT_CACHE-MODE: ${{ inputs.cache-mode }}
           INPUT_BUILD-SECRETS: ${{ secrets.build-secrets }}
+          INPUT_SECRET-IDS: ${{ needs.prepare.outputs.secretIds }}
           INPUT_CONTEXT: ${{ inputs.context }}
           INPUT_FILES: ${{ inputs.files }}
           INPUT_OUTPUT: ${{ inputs.output }}
@@ -878,6 +895,7 @@ jobs:
             const inpCacheScope = core.getInput('cache-scope');
             const inpCacheMode = core.getInput('cache-mode');
             const inpBuildSecrets = core.getInput('build-secrets');
+            const inpSecretIds = core.getInput('secret-ids');
             const inpContext = core.getInput('context');
             const inpFiles = Util.getInputList('files');
             const inpOutput = core.getInput('output');
@@ -901,6 +919,7 @@ jobs:
               tags: inpMetaTags
             };
             const renderTemplate = value => Util.compileHandlebars(value, {noEscape: true}, {meta});
+
             const parseBuildSecrets = value => {
               const normalized = value.trim();
               if (!normalized) {
@@ -950,6 +969,19 @@ jobs:
               }
               return secrets;
             };
+
+            const validateBuildSecrets = (secrets, secretIds) => {
+              for (const {target, id} of secrets) {
+                const targetSecretIds = secretIds[target];
+                if (!targetSecretIds) {
+                  throw new Error(`Build secret target "${target}" is not part of the resolved Bake definition`);
+                }
+                if (!Array.isArray(targetSecretIds) || !targetSecretIds.includes(id)) {
+                  throw new Error(`Build secret "${id}" must be declared in Bake target "${target}" before it can be provided through build-secrets`);
+                }
+              }
+            };
+
             const toBuildSecretEnvName = (id, index) => `BUILD_SECRET_${index}_${id.toUpperCase().replace(/[^A-Z0-9_]/g, '_')}`;
             
             const gitContextAttrs = GitHub.context.ref.startsWith('refs/tags/') ? {checksum: GitHub.context.sha} : {'fetch-by-commit': 'true'};
@@ -977,7 +1009,16 @@ jobs:
               core.setFailed(err.message);
               return;
             }
-            
+
+            let secretIds;
+            try {
+              secretIds = JSON.parse(inpSecretIds || '{}');
+              validateBuildSecrets(buildSecrets, secretIds);
+            } catch (err) {
+              core.setFailed(err.message);
+              return;
+            }
+
             const envs = Object.assign({},
               inpVars ? inpVars.reduce((acc, curr) => {
                 const idx = curr.indexOf('=');

--- a/.github/workflows/bake.yml
+++ b/.github/workflows/bake.yml
@@ -143,6 +143,9 @@ on:
       registry-auths:
         description: "Raw authentication to registries, defined as YAML objects (for image output)"
         required: false
+      build-secrets:
+        description: "YAML object mapping BuildKit secret IDs, optionally target-scoped, to secret values"
+        required: false
       github-token:
         description: "GitHub Token used to authenticate against the repository for Git context"
         required: false
@@ -481,7 +484,7 @@ jobs:
               }
             );
             await core.group(`Set envs`, async () => {
-              core.info(JSON.stringify(envs, null, 2));
+              core.info(JSON.stringify(Object.keys(envs).sort(), null, 2));
             });
 
             const metaImages = inpMetaImages.map(image => image.toLowerCase());
@@ -832,6 +835,7 @@ jobs:
           INPUT_CACHE: ${{ inputs.cache }}
           INPUT_CACHE-SCOPE: ${{ inputs.cache-scope }}
           INPUT_CACHE-MODE: ${{ inputs.cache-mode }}
+          INPUT_BUILD-SECRETS: ${{ secrets.build-secrets }}
           INPUT_CONTEXT: ${{ inputs.context }}
           INPUT_FILES: ${{ inputs.files }}
           INPUT_OUTPUT: ${{ inputs.output }}
@@ -855,7 +859,14 @@ jobs:
             const { Build } = require('@docker/github-builder-runtime/lib/buildx/build');
             const { GitHub } = require('@docker/github-builder-runtime/lib/github/github');
             const { Util } = require('@docker/github-builder-runtime/lib/util');
-            
+
+            let yaml;
+            try {
+              yaml = require('js-yaml');
+            } catch {
+              yaml = require('@docker/github-builder-runtime/node_modules/js-yaml');
+            }
+
             const inpPlatform = core.getInput('platform');
             const platformPairSuffix = inpPlatform ? `-${inpPlatform.replace(/\//g, '-')}` : '';
             core.setOutput('platform-pair-suffix', platformPairSuffix);
@@ -866,6 +877,7 @@ jobs:
             const inpCache = core.getBooleanInput('cache');
             const inpCacheScope = core.getInput('cache-scope');
             const inpCacheMode = core.getInput('cache-mode');
+            const inpBuildSecrets = core.getInput('build-secrets');
             const inpContext = core.getInput('context');
             const inpFiles = Util.getInputList('files');
             const inpOutput = core.getInput('output');
@@ -889,6 +901,56 @@ jobs:
               tags: inpMetaTags
             };
             const renderTemplate = value => Util.compileHandlebars(value, {noEscape: true}, {meta});
+            const parseBuildSecrets = value => {
+              const normalized = value.trim();
+              if (!normalized) {
+                return [];
+              }
+              let parsed;
+              try {
+                parsed = yaml.load(normalized, {schema: yaml.FAILSAFE_SCHEMA});
+              } catch (err) {
+                const location = err.mark ? ` at line ${err.mark.line + 1}, column ${err.mark.column + 1}` : '';
+                throw new Error(`Failed to parse build-secrets YAML${location}`);
+              }
+              if (!parsed) {
+                return [];
+              }
+              if (Array.isArray(parsed) || typeof parsed !== 'object') {
+                throw new Error('build-secrets must be a YAML object');
+              }
+              const secrets = [];
+              const seen = new Set();
+              for (const [key, secret] of Object.entries(parsed)) {
+                const separator = key.lastIndexOf('.');
+                const target = separator === -1 ? inpTarget : key.substring(0, separator);
+                const id = separator === -1 ? key : key.substring(separator + 1);
+                if (!target) {
+                  throw new Error(`Invalid build secret target for "${key}": target must not be empty`);
+                }
+                if (!/^[A-Za-z0-9_.-]+$/.test(target)) {
+                  throw new Error(`Invalid build secret target "${target}": use letters, digits, dots, underscores or dashes`);
+                }
+                if (!/^[A-Za-z0-9_-]+$/.test(id)) {
+                  throw new Error(`Invalid build secret id "${id}": use letters, digits, underscores or dashes`);
+                }
+                if (typeof secret !== 'string') {
+                  throw new Error(`build-secrets value for "${key}" must be a string`);
+                }
+                if (secret.length === 0) {
+                  throw new Error(`build-secrets value for "${key}" must not be empty`);
+                }
+                const ref = `${target}\0${id}`;
+                if (seen.has(ref)) {
+                  throw new Error(`Build secret id "${id}" is defined more than once for target "${target}"`);
+                }
+                seen.add(ref);
+                core.setSecret(secret);
+                secrets.push({target, id, secret});
+              }
+              return secrets;
+            };
+            const toBuildSecretEnvName = (id, index) => `BUILD_SECRET_${index}_${id.toUpperCase().replace(/[^A-Z0-9_]/g, '_')}`;
             
             const gitContextAttrs = GitHub.context.ref.startsWith('refs/tags/') ? {checksum: GitHub.context.sha} : {'fetch-by-commit': 'true'};
             const bakeSource = await new Build().gitContext({subdir: inpContext, attrs: gitContextAttrs});
@@ -907,6 +969,14 @@ jobs:
               core.info(sbom);
               core.setOutput('sbom', sbom);
             });
+
+            let buildSecrets;
+            try {
+              buildSecrets = parseBuildSecrets(inpBuildSecrets);
+            } catch (err) {
+              core.setFailed(err.message);
+              return;
+            }
             
             const envs = Object.assign({},
               inpVars ? inpVars.reduce((acc, curr) => {
@@ -921,9 +991,17 @@ jobs:
                 BUILDX_BAKE_GIT_AUTH_TOKEN: inpGitHubToken
               }
             );
+            const secretOverrides = [];
+            buildSecrets.forEach(({target, id, secret}, index) => {
+              const envName = toBuildSecretEnvName(id, index);
+              envs[envName] = secret;
+              secretOverrides.push(`${target}.secrets+=id=${id},env=${envName}`);
+            });
             await core.group(`Set envs`, async () => {
-              core.info(JSON.stringify(envs, null, 2));
-              core.setOutput('envs', JSON.stringify(envs));
+              core.info(JSON.stringify(Object.keys(envs).sort(), null, 2));
+              Object.entries(envs).forEach(([key, value]) => {
+                core.exportVariable(key, value);
+              });
             });
             
             let bakeFiles = inpFiles;
@@ -985,6 +1063,7 @@ jobs:
                 bakeOverrides.push(`*.cache-from=type=gha,scope=${inpCacheScope || inpTarget}${platformPairSuffix}`);
                 bakeOverrides.push(`*.cache-to=type=gha,ignore-error=true,scope=${inpCacheScope || inpTarget}${platformPairSuffix},mode=${inpCacheMode}`);
               }
+              bakeOverrides.push(...secretOverrides);
               core.info(JSON.stringify(bakeOverrides, null, 2));
               core.setOutput('overrides', bakeOverrides.join(os.EOL));
             });
@@ -1049,7 +1128,6 @@ jobs:
           targets: ${{ steps.prepare.outputs.target }}
           sbom: ${{ steps.prepare.outputs.sbom }}
           set: ${{ steps.prepare.outputs.overrides }}
-        env: ${{ fromJson(steps.prepare.outputs.envs || '{}') }}
       -
         name: Get image digest
         id: get-image-digest

--- a/.github/workflows/bake.yml
+++ b/.github/workflows/bake.yml
@@ -212,7 +212,7 @@ jobs:
       metaImages: ${{ steps.set.outputs.metaImages }}
       sign: ${{ steps.set.outputs.sign }}
       privateRepo: ${{ steps.set.outputs.privateRepo }}
-      secretIds: ${{ steps.set.outputs.secretIds }}
+      targets: ${{ steps.set.outputs.targets }}
       ghaCacheSign: ${{ steps.set.outputs.ghaCacheSign }}
     steps:
       -
@@ -523,16 +523,6 @@ jobs:
                   const match = value.match(/^target:(.+)$/);
                   return match ? match[1] : undefined;
                 };
-                const parseSecretId = secret => {
-                  if (typeof secret === 'string') {
-                    const idAttr = secret.split(',').map(attr => attr.trim()).find(attr => attr.startsWith('id='));
-                    return idAttr ? idAttr.substring(3) : undefined;
-                  }
-                  if (secret && typeof secret === 'object' && typeof secret.id === 'string') {
-                    return secret.id;
-                  }
-                  return undefined;
-                };
                 const resolveTarget = () => {
                   if (targetDefs[inpTarget]) {
                     return inpTarget;
@@ -561,11 +551,7 @@ jobs:
                 if (unsupportedTargets.length > 0) {
                   throw new Error(`Only one target can be built at once, found unsupported targets: ${unsupportedTargets.join(', ')}`);
                 }
-                const secretIds = {};
-                for (const name of allowedTargets) {
-                  secretIds[name] = (targetDefs[name]?.secret || []).map(parseSecretId).filter(Boolean);
-                }
-                core.setOutput('secretIds', JSON.stringify(secretIds));
+                core.setOutput('targets', JSON.stringify([...allowedTargets]));
               });
             } catch (error) {
               core.setFailed(error);
@@ -852,7 +838,7 @@ jobs:
           INPUT_CACHE-SCOPE: ${{ inputs.cache-scope }}
           INPUT_CACHE-MODE: ${{ inputs.cache-mode }}
           INPUT_BUILD-SECRETS: ${{ secrets.build-secrets }}
-          INPUT_SECRET-IDS: ${{ needs.prepare.outputs.secretIds }}
+          INPUT_TARGETS: ${{ needs.prepare.outputs.targets }}
           INPUT_CONTEXT: ${{ inputs.context }}
           INPUT_FILES: ${{ inputs.files }}
           INPUT_OUTPUT: ${{ inputs.output }}
@@ -895,7 +881,7 @@ jobs:
             const inpCacheScope = core.getInput('cache-scope');
             const inpCacheMode = core.getInput('cache-mode');
             const inpBuildSecrets = core.getInput('build-secrets');
-            const inpSecretIds = core.getInput('secret-ids');
+            const inpTargets = core.getInput('targets');
             const inpContext = core.getInput('context');
             const inpFiles = Util.getInputList('files');
             const inpOutput = core.getInput('output');
@@ -920,6 +906,11 @@ jobs:
             };
             const renderTemplate = value => Util.compileHandlebars(value, {noEscape: true}, {meta});
 
+            const isInputKeySafe = value => value && !/[\r\n=]/.test(value);
+            const parseBuildSecretKey = key => {
+              const separator = key.lastIndexOf('.');
+              return separator === -1 ? {target: inpTarget, id: key} : {target: key.substring(0, separator), id: key.substring(separator + 1)};
+            };
             const parseBuildSecrets = value => {
               const normalized = value.trim();
               if (!normalized) {
@@ -938,50 +929,18 @@ jobs:
               if (Array.isArray(parsed) || typeof parsed !== 'object') {
                 throw new Error('build-secrets must be a YAML object');
               }
-              const secrets = [];
-              const seen = new Set();
-              for (const [key, secret] of Object.entries(parsed)) {
-                const separator = key.lastIndexOf('.');
-                const target = separator === -1 ? inpTarget : key.substring(0, separator);
-                const id = separator === -1 ? key : key.substring(separator + 1);
-                if (!target) {
-                  throw new Error(`Invalid build secret target for "${key}": target must not be empty`);
-                }
-                if (!/^[A-Za-z0-9_.-]+$/.test(target)) {
-                  throw new Error(`Invalid build secret target "${target}": use letters, digits, dots, underscores or dashes`);
-                }
-                if (!/^[A-Za-z0-9_-]+$/.test(id)) {
-                  throw new Error(`Invalid build secret id "${id}": use letters, digits, underscores or dashes`);
+              return Object.entries(parsed).map(([key, secret]) => {
+                const {target, id} = parseBuildSecretKey(key);
+                if (!isInputKeySafe(target) || !isInputKeySafe(id)) {
+                  throw new Error(`Invalid build-secrets key "${key}": use "secret_id" or "target.secret_id" without empty names, line breaks or "="`);
                 }
                 if (typeof secret !== 'string') {
                   throw new Error(`build-secrets value for "${key}" must be a string`);
                 }
-                if (secret.length === 0) {
-                  throw new Error(`build-secrets value for "${key}" must not be empty`);
-                }
-                const ref = `${target}\0${id}`;
-                if (seen.has(ref)) {
-                  throw new Error(`Build secret id "${id}" is defined more than once for target "${target}"`);
-                }
-                seen.add(ref);
                 core.setSecret(secret);
-                secrets.push({target, id, secret});
-              }
-              return secrets;
+                return {target, id, secret};
+              });
             };
-
-            const validateBuildSecrets = (secrets, secretIds) => {
-              for (const {target, id} of secrets) {
-                const targetSecretIds = secretIds[target];
-                if (!targetSecretIds) {
-                  throw new Error(`Build secret target "${target}" is not part of the resolved Bake definition`);
-                }
-                if (!Array.isArray(targetSecretIds) || !targetSecretIds.includes(id)) {
-                  throw new Error(`Build secret "${id}" must be declared in Bake target "${target}" before it can be provided through build-secrets`);
-                }
-              }
-            };
-
             const toBuildSecretEnvName = (id, index) => `BUILD_SECRET_${index}_${id.toUpperCase().replace(/[^A-Z0-9_]/g, '_')}`;
             
             const gitContextAttrs = GitHub.context.ref.startsWith('refs/tags/') ? {checksum: GitHub.context.sha} : {'fetch-by-commit': 'true'};
@@ -1010,10 +969,15 @@ jobs:
               return;
             }
 
-            let secretIds;
+            let targets;
             try {
-              secretIds = JSON.parse(inpSecretIds || '{}');
-              validateBuildSecrets(buildSecrets, secretIds);
+              targets = JSON.parse(inpTargets || '[]');
+              const allowedTargets = new Set(targets);
+              for (const {target} of buildSecrets) {
+                if (!allowedTargets.has(target)) {
+                  throw new Error(`Build secret target "${target}" is not part of the resolved Bake definition`);
+                }
+              }
             } catch (err) {
               core.setFailed(err.message);
               return;
@@ -1036,7 +1000,7 @@ jobs:
             buildSecrets.forEach(({target, id, secret}, index) => {
               const envName = toBuildSecretEnvName(id, index);
               envs[envName] = secret;
-              secretOverrides.push(`${target}.secrets+=id=${id},env=${envName}`);
+              secretOverrides.push(`${target}.secret.${id}=env=${envName}`);
             });
             await core.group(`Set envs`, async () => {
               core.info(JSON.stringify(Object.keys(envs).sort(), null, 2));

--- a/.github/workflows/bake.yml
+++ b/.github/workflows/bake.yml
@@ -337,7 +337,7 @@ jobs:
             const inpArtifactUpload = core.getBooleanInput('artifact-upload');
             const inpJobNamePrefix = core.getInput('job-name-prefix');
             const inpContext = core.getInput('context');
-            const inpVars = Util.getInputList('vars');
+            const inpVars = Util.getInputList('vars', {ignoreComma: true, quote: false});
             const inpFiles = Util.getInputList('files');
             const inpOutput = core.getInput('output');
             const inpPush = core.getBooleanInput('push');
@@ -471,23 +471,26 @@ jobs:
               core.info(bakeSource);
             });
             
-            const envs = Object.assign({},
-              inpVars ? inpVars.reduce((acc, curr) => {
-                const idx = curr.indexOf('=');
-                if (idx !== -1) {
-                  acc[curr.substring(0, idx)] = curr.substring(idx + 1);
-                }
-                return acc;
-              }, {}) : {},
-              {
-                BUILDKIT_MULTI_PLATFORM: '1',
-                BUILDX_BAKE_GIT_AUTH_TOKEN: inpGitHubToken
-              }
-            );
+            // Preserve GitHub's default workflow context variables without allowing arbitrary runner env lookup in Bake.
+            const defaultBakeVars = Object.keys(process.env).filter(key => key.startsWith('GITHUB_') || key.startsWith('RUNNER_')).sort().map(key => `${key}=${process.env[key] || ''}`);
+            const bakeVars = [...defaultBakeVars, ...inpVars];
+            const bakeVarKeys = bakeVars.map(value => {
+              const idx = value.indexOf('=');
+              return idx === -1 ? '<invalid>' : value.substring(0, idx);
+            });
+            await core.group(`Set bake vars`, async () => {
+              core.info(JSON.stringify(bakeVarKeys.sort(), null, 2));
+            });
+            
+            const envs = {
+              BUILDKIT_MULTI_PLATFORM: '1',
+              BUILDX_BAKE_DISABLE_VARS_ENV_LOOKUP: '1',
+              BUILDX_BAKE_GIT_AUTH_TOKEN: inpGitHubToken
+            };
             await core.group(`Set envs`, async () => {
               core.info(JSON.stringify(Object.keys(envs).sort(), null, 2));
             });
-
+            
             const metaImages = inpMetaImages.map(image => image.toLowerCase());
             await core.group(`Set metaImages output`, async () => {
               core.info(JSON.stringify(metaImages, null, 2));
@@ -504,7 +507,8 @@ jobs:
                   overrides: inpSet,
                   sbom: inpSbom ? `generator=${inpSbomImage}` : 'false',
                   source: bakeSource,
-                  targets: [inpTarget]
+                  targets: [inpTarget],
+                  vars: bakeVars
                 }, {
                   env: Object.keys(envs).length > 0 ? envs : undefined
                 });
@@ -889,7 +893,7 @@ jobs:
             const inpSbom = core.getBooleanInput('sbom');
             const inpSet = Util.getInputList('set', {ignoreComma: true, quote: false});
             const inpTarget = core.getInput('target');
-            const inpVars = Util.getInputList('vars');
+            const inpVars = Util.getInputList('vars', {ignoreComma: true, quote: false});
             const inpMetaImages = core.getMultilineInput('meta-images');
             const inpMetaVersion = core.getInput('meta-version');
             const inpMetaTags = core.getMultilineInput('meta-tags');
@@ -983,25 +987,31 @@ jobs:
               return;
             }
 
-            const envs = Object.assign({},
-              inpVars ? inpVars.reduce((acc, curr) => {
-                const idx = curr.indexOf('=');
-                if (idx !== -1) {
-                  acc[curr.substring(0, idx)] = curr.substring(idx + 1);
-                }
-                return acc;
-              }, {}) : {},
-              {
-                BUILDKIT_MULTI_PLATFORM: '1',
-                BUILDX_BAKE_GIT_AUTH_TOKEN: inpGitHubToken
-              }
-            );
+            // Preserve GitHub's default workflow context variables without allowing arbitrary runner env lookup in Bake.
+            const defaultBakeVars = Object.keys(process.env).filter(key => key.startsWith('GITHUB_') || key.startsWith('RUNNER_')).sort().map(key => `${key}=${process.env[key] || ''}`);
+            const bakeVars = [...defaultBakeVars, ...inpVars];
+            const bakeVarKeys = bakeVars.map(value => {
+              const idx = value.indexOf('=');
+              return idx === -1 ? '<invalid>' : value.substring(0, idx);
+            });
+            await core.group(`Set bake vars`, async () => {
+              core.info(JSON.stringify(bakeVarKeys.sort(), null, 2));
+              core.setOutput('vars', bakeVars.join(os.EOL));
+            });
+
+            const envs = {
+              BUILDKIT_MULTI_PLATFORM: '1',
+              BUILDX_BAKE_DISABLE_VARS_ENV_LOOKUP: '1',
+              BUILDX_BAKE_GIT_AUTH_TOKEN: inpGitHubToken
+            };
+
             const secretOverrides = [];
             buildSecrets.forEach(({target, id, secret}, index) => {
               const envName = toBuildSecretEnvName(id, index);
               envs[envName] = secret;
               secretOverrides.push(`${target}.secret.${id}=env=${envName}`);
             });
+
             await core.group(`Set envs`, async () => {
               core.info(JSON.stringify(Object.keys(envs).sort(), null, 2));
               Object.entries(envs).forEach(([key, value]) => {
@@ -1133,6 +1143,7 @@ jobs:
           targets: ${{ steps.prepare.outputs.target }}
           sbom: ${{ steps.prepare.outputs.sbom }}
           set: ${{ steps.prepare.outputs.overrides }}
+          vars: ${{ steps.prepare.outputs.vars }}
       -
         name: Get image digest
         id: get-image-digest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -154,6 +154,9 @@ on:
       registry-auths:
         description: "Raw authentication to registries, defined as YAML objects (for image output)"
         required: false
+      build-secrets:
+        description: "YAML object mapping BuildKit secret IDs to secret values"
+        required: false
       github-token:
         description: "GitHub Token used to authenticate against the repository for Git context"
         required: false
@@ -733,6 +736,7 @@ jobs:
           INPUT_CACHE: ${{ inputs.cache }}
           INPUT_CACHE-SCOPE: ${{ inputs.cache-scope }}
           INPUT_CACHE-MODE: ${{ inputs.cache-mode }}
+          INPUT_BUILD-SECRETS: ${{ secrets.build-secrets }}
           INPUT_LABELS: ${{ inputs.labels }}
           INPUT_CONTEXT: ${{ inputs.context }}
           INPUT_OUTPUT: ${{ inputs.output }}
@@ -747,12 +751,20 @@ jobs:
           INPUT_META-ANNOTATIONS: ${{ steps.meta.outputs.annotations }}
           INPUT_SET-META-LABELS: ${{ inputs.set-meta-labels }}
           INPUT_META-LABELS: ${{ steps.meta.outputs.labels }}
+          INPUT_GITHUB-TOKEN: ${{ secrets.github-token || github.token }}
         with:
           script: |
             const { Build } = require('@docker/github-builder-runtime/lib/buildx/build');
             const { GitHub } = require('@docker/github-builder-runtime/lib/github/github');
             const { Util } = require('@docker/github-builder-runtime/lib/util');
-            
+
+            let yaml;
+            try {
+              yaml = require('js-yaml');
+            } catch {
+              yaml = require('@docker/github-builder-runtime/node_modules/js-yaml');
+            }
+
             const inpPlatform = core.getInput('platform');
             const platformPairSuffix = inpPlatform ? `-${inpPlatform.replace(/\//g, '-')}` : '';
             core.setOutput('platform-pair-suffix', platformPairSuffix);
@@ -766,6 +778,7 @@ jobs:
             const inpCache = core.getBooleanInput('cache');
             const inpCacheScope = core.getInput('cache-scope');
             const inpCacheMode = core.getInput('cache-mode');
+            const inpBuildSecrets = core.getInput('build-secrets');
             const inpContext = core.getInput('context');
             const inpLabels = core.getInput('labels');
             const inpOutput = core.getInput('output');
@@ -781,6 +794,7 @@ jobs:
             const inpMetaAnnotations = core.getMultilineInput('meta-annotations');
             const inpSetMetaLabels = core.getBooleanInput('set-meta-labels');
             const inpMetaLabels = core.getMultilineInput('meta-labels');
+            const inpGitHubToken = core.getInput('github-token');
             
             const meta = {
               version: inpMetaVersion,
@@ -789,6 +803,44 @@ jobs:
 
             const renderTemplate = value => Util.compileHandlebars(value, {noEscape: true}, {meta});
             const toMultilineInput = value => value.split(/\r?\n/).map(line => line.trim()).filter(Boolean);
+            const parseBuildSecrets = value => {
+              const normalized = value.trim();
+              if (!normalized) {
+                return {};
+              }
+              let parsed;
+              try {
+                parsed = yaml.load(normalized, {schema: yaml.FAILSAFE_SCHEMA});
+              } catch (err) {
+                const location = err.mark ? ` at line ${err.mark.line + 1}, column ${err.mark.column + 1}` : '';
+                throw new Error(`Failed to parse build-secrets YAML${location}`);
+              }
+              if (!parsed) {
+                return {};
+              }
+              if (Array.isArray(parsed) || typeof parsed !== 'object') {
+                throw new Error('build-secrets must be a YAML object');
+              }
+              const secrets = {};
+              for (const [id, secret] of Object.entries(parsed)) {
+                if (!/^[A-Za-z0-9_-]+$/.test(id)) {
+                  throw new Error(`Invalid build secret id "${id}": use letters, digits, underscores or dashes`);
+                }
+                if (id === 'GIT_AUTH_TOKEN') {
+                  throw new Error('Build secret id "GIT_AUTH_TOKEN" is reserved for Git context authentication');
+                }
+                if (typeof secret !== 'string') {
+                  throw new Error(`build-secrets value for "${id}" must be a string`);
+                }
+                if (secret.length === 0) {
+                  throw new Error(`build-secrets value for "${id}" must not be empty`);
+                }
+                core.setSecret(secret);
+                secrets[id] = secret;
+              }
+              return secrets;
+            };
+            const toBuildSecretEnvName = (id, index) => `BUILD_SECRET_${index}_${id.toUpperCase().replace(/[^A-Z0-9_]/g, '_')}`;
             
             const gitContextAttrs = GitHub.context.ref.startsWith('refs/tags/') ? {checksum: GitHub.context.sha} : {'fetch-by-commit': 'true'};
             const buildContext = await new Build().gitContext({subdir: inpContext, attrs: gitContextAttrs});
@@ -845,6 +897,28 @@ jobs:
             }
             core.setOutput('labels', labels.join('\n'));
             core.setOutput('build-args', buildArgs);
+
+            let buildSecrets;
+            try {
+              buildSecrets = parseBuildSecrets(inpBuildSecrets);
+            } catch (err) {
+              core.setFailed(err.message);
+              return;
+            }
+            const envs = {
+              BUILDKIT_MULTI_PLATFORM: '1',
+              GIT_AUTH_TOKEN: inpGitHubToken
+            };
+            const secretEnvs = ['GIT_AUTH_TOKEN=GIT_AUTH_TOKEN'];
+            Object.entries(buildSecrets).forEach(([id, secret], index) => {
+              const envName = toBuildSecretEnvName(id, index);
+              envs[envName] = secret;
+              secretEnvs.push(`${id}=${envName}`);
+            });
+            Object.entries(envs).forEach(([key, value]) => {
+              core.exportVariable(key, value);
+            });
+            core.setOutput('secret-envs', secretEnvs.join('\n'));
             
             if (GitHub.context.payload.repository?.private ?? false) {
               // if this is a private repository, we set min provenance mode
@@ -920,13 +994,10 @@ jobs:
           platforms: ${{ steps.prepare.outputs.platform }}
           provenance: ${{ steps.prepare.outputs.provenance }}
           sbom: ${{ steps.prepare.outputs.sbom }}
-          secret-envs: GIT_AUTH_TOKEN=GIT_AUTH_TOKEN
+          secret-envs: ${{ steps.prepare.outputs.secret-envs }}
           shm-size: ${{ inputs.shm-size }}
           target: ${{ inputs.target }}
           ulimit: ${{ inputs.ulimit }}
-        env:
-          BUILDKIT_MULTI_PLATFORM: 1
-          GIT_AUTH_TOKEN: ${{ secrets.github-token || github.token }}
       -
         name: Login to registry for signing
         if: ${{ needs.prepare.outputs.sign == 'true' && inputs.output == 'image' && env.REGISTRY_AUTHS_PRESENT == 'true' }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -800,9 +800,9 @@ jobs:
               version: inpMetaVersion,
               tags: inpMetaTags
             };
-
             const renderTemplate = value => Util.compileHandlebars(value, {noEscape: true}, {meta});
-            const toMultilineInput = value => value.split(/\r?\n/).map(line => line.trim()).filter(Boolean);
+            
+            const isInputKeySafe = value => value && !/[\r\n=]/.test(value);
             const parseBuildSecrets = value => {
               const normalized = value.trim();
               if (!normalized) {
@@ -821,10 +821,9 @@ jobs:
               if (Array.isArray(parsed) || typeof parsed !== 'object') {
                 throw new Error('build-secrets must be a YAML object');
               }
-              const secrets = {};
               for (const [id, secret] of Object.entries(parsed)) {
-                if (!/^[A-Za-z0-9_-]+$/.test(id)) {
-                  throw new Error(`Invalid build secret id "${id}": use letters, digits, underscores or dashes`);
+                if (!isInputKeySafe(id)) {
+                  throw new Error(`Invalid build secret id "${id}": must not be empty or contain line breaks or "="`);
                 }
                 if (id === 'GIT_AUTH_TOKEN') {
                   throw new Error('Build secret id "GIT_AUTH_TOKEN" is reserved for Git context authentication');
@@ -832,13 +831,9 @@ jobs:
                 if (typeof secret !== 'string') {
                   throw new Error(`build-secrets value for "${id}" must be a string`);
                 }
-                if (secret.length === 0) {
-                  throw new Error(`build-secrets value for "${id}" must not be empty`);
-                }
                 core.setSecret(secret);
-                secrets[id] = secret;
               }
-              return secrets;
+              return parsed;
             };
             const toBuildSecretEnvName = (id, index) => `BUILD_SECRET_${index}_${id.toUpperCase().replace(/[^A-Z0-9_]/g, '_')}`;
             
@@ -879,6 +874,7 @@ jobs:
             let labels;
             let buildArgs;
             try {
+              const toMultilineInput = value => value.split(/\r?\n/).map(line => line.trim()).filter(Boolean);
               annotations = toMultilineInput(renderTemplate(inpAnnotations));
               labels = toMultilineInput(renderTemplate(inpLabels));
               buildArgs = renderTemplate(inpBuildArgs);

--- a/README.md
+++ b/README.md
@@ -418,7 +418,8 @@ passes these values through `docker/build-push-action` `secret-envs`, and the
 bake workflow appends matching `target.secrets+=id=...,env=...` overrides. For
 the bake workflow, an unqualified key applies to the workflow `target` input. A
 key written as `target.secret_id` applies only to that Bake target. This
-target-scoped key form is only accepted by the bake workflow:
+target-scoped key form is only accepted by the bake workflow. The target must
+already declare a matching secret ID in the Bake definition:
 
 ```yaml
 secrets:
@@ -429,7 +430,7 @@ secrets:
 
 Bake targets can declare local secret sources for direct `docker buildx bake`
 usage. When the reusable workflow receives a matching `build-secrets` entry, it
-overrides that source with the workflow-provided secret value:
+overrides that declared source with the workflow-provided secret value:
 
 ```hcl
 target "default" {

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ ___
   * [Secrets](#secrets-1)
   * [Outputs](#outputs-1)
 * [Notes](#notes)
+  * [BuildKit secrets](#buildkit-secrets)
   * [Signed GitHub Actions cache](#signed-github-actions-cache)
   * [Registry identities](#registry-identities)
     * [Docker Hub OIDC](#docker-hub-oidc)
@@ -258,6 +259,7 @@ jobs:
 | Name             | Default               | Description                                                                    |
 |------------------|-----------------------|--------------------------------------------------------------------------------|
 | `registry-auths` |                       | Raw authentication to registries, defined as YAML objects (for `image` output) |
+| `build-secrets`  |                       | YAML object mapping BuildKit secret IDs to secret values                       |
 | `github-token`   | `${{ github.token }}` | GitHub Token used to authenticate against the repository for Git context       |
 
 ### Outputs
@@ -370,6 +372,7 @@ jobs:
 | Name             | Default               | Description                                                                    |
 |------------------|-----------------------|--------------------------------------------------------------------------------|
 | `registry-auths` |                       | Raw authentication to registries, defined as YAML objects (for `image` output) |
+| `build-secrets`  |                       | YAML object mapping BuildKit secret IDs, optionally target-scoped, to secret values |
 | `github-token`   | `${{ github.token }}` | GitHub Token used to authenticate against the repository for Git context       |
 
 ### Outputs
@@ -389,6 +392,59 @@ with `builder-outputs: ${{ toJSON(needs.<job_id>.outputs) }}`.
 | `signed`                 | Bool   | Whether attestation manifests or local artifacts were signed                 |
 
 ## Notes
+
+### BuildKit secrets
+
+The `build-secrets` secret is shared by the build and bake workflows. It must
+be a YAML object. For the build workflow, each key is the BuildKit secret ID and
+each value is the secret payload. The bake workflow accepts the same unqualified
+keys. Secret IDs may contain letters, digits, underscores, and dashes:
+
+```yaml
+secrets:
+  build-secrets: |
+    npmrc: ${{ toJSON(secrets.NPMRC) }}
+    aws_credentials: ${{ toJSON(secrets.AWS_CREDENTIALS) }}
+    inline_config: |
+      first line
+      second line
+```
+
+Use `toJSON(...)` when injecting GitHub secrets so values that contain newlines
+or YAML syntax are preserved as a single YAML scalar.
+
+Each secret is exposed as an env-backed BuildKit secret. The build workflow
+passes these values through `docker/build-push-action` `secret-envs`, and the
+bake workflow appends matching `target.secrets+=id=...,env=...` overrides. For
+the bake workflow, an unqualified key applies to the workflow `target` input. A
+key written as `target.secret_id` applies only to that Bake target. This
+target-scoped key form is only accepted by the bake workflow:
+
+```yaml
+secrets:
+  build-secrets: |
+    default.npmrc: ${{ toJSON(secrets.NPMRC) }}
+    release.aws_credentials: ${{ toJSON(secrets.AWS_CREDENTIALS) }}
+```
+
+Bake targets can declare local secret sources for direct `docker buildx bake`
+usage. When the reusable workflow receives a matching `build-secrets` entry, it
+overrides that source with the workflow-provided secret value:
+
+```hcl
+target "default" {
+  secret = [
+    "id=npmrc,env=NPMRC",
+    "type=file,id=aws_credentials,src=${HOME}/.aws/credentials",
+  ]
+}
+```
+
+The workflow does not accept file-based secret payloads. `build-secrets` values
+are always exposed to BuildKit from environment variables. A Bake target can
+still declare a file-based source for local `docker buildx bake` usage, as shown
+above, but a matching `build-secrets` entry overrides that source in the reusable
+workflow.
 
 ### Signed GitHub Actions cache
 

--- a/README.md
+++ b/README.md
@@ -367,13 +367,19 @@ jobs:
 | `meta-annotations`        | List   |                                       | [List of custom annotations](https://github.com/docker/metadata-action?tab=readme-ov-file#overwrite-labels-and-annotations)                                                                                                                                                                          |
 | `meta-flavor`             | List   |                                       | [Flavor](https://github.com/docker/metadata-action?tab=readme-ov-file#flavor-input) defines a global behavior for `meta-tags`                                                                                                                                                                        |
 
+> [!NOTE]
+> The `vars` input is passed to Buildx as explicit Bake variables. Ambient
+> environment lookup for Bake variables is disabled, except that step environment
+> variables with `GITHUB_` or `RUNNER_` prefixes are forwarded as explicit vars
+> for workflows that declare them in their Bake definition.
+
 ### Secrets
 
-| Name             | Default               | Description                                                                    |
-|------------------|-----------------------|--------------------------------------------------------------------------------|
-| `registry-auths` |                       | Raw authentication to registries, defined as YAML objects (for `image` output) |
+| Name             | Default               | Description                                                                         |
+|------------------|-----------------------|-------------------------------------------------------------------------------------|
+| `registry-auths` |                       | Raw authentication to registries, defined as YAML objects (for `image` output)      |
 | `build-secrets`  |                       | YAML object mapping BuildKit secret IDs, optionally target-scoped, to secret values |
-| `github-token`   | `${{ github.token }}` | GitHub Token used to authenticate against the repository for Git context       |
+| `github-token`   | `${{ github.token }}` | GitHub Token used to authenticate against the repository for Git context            |
 
 ### Outputs
 

--- a/README.md
+++ b/README.md
@@ -398,7 +398,7 @@ with `builder-outputs: ${{ toJSON(needs.<job_id>.outputs) }}`.
 The `build-secrets` secret is shared by the build and bake workflows. It must
 be a YAML object. For the build workflow, each key is the BuildKit secret ID and
 each value is the secret payload. The bake workflow accepts the same unqualified
-keys. Secret IDs may contain letters, digits, underscores, and dashes:
+keys.
 
 ```yaml
 secrets:
@@ -415,11 +415,12 @@ or YAML syntax are preserved as a single YAML scalar.
 
 Each secret is exposed as an env-backed BuildKit secret. The build workflow
 passes these values through `docker/build-push-action` `secret-envs`, and the
-bake workflow appends matching `target.secrets+=id=...,env=...` overrides. For
+bake workflow sets matching `target.secret.<id>=env=...` source overrides. For
 the bake workflow, an unqualified key applies to the workflow `target` input. A
 key written as `target.secret_id` applies only to that Bake target. This
-target-scoped key form is only accepted by the bake workflow. The target must
-already declare a matching secret ID in the Bake definition:
+target-scoped key form is only accepted by the bake workflow. The target must be
+part of the resolved Bake build, and Buildx requires the target to already
+declare a matching secret ID in the Bake definition:
 
 ```yaml
 secrets:

--- a/test/docker-bake.hcl
+++ b/test/docker-bake.hcl
@@ -38,6 +38,14 @@ target "hello-cross" {
   platforms = ["linux/amd64", "linux/arm64"]
 }
 
+target "secret" {
+  dockerfile = "secret.Dockerfile"
+  secret = [
+    "id=fixture_plain,env=FIXTURE_PLAIN",
+    "id=fixture_json,env=FIXTURE_JSON",
+  ]
+}
+
 target "go-cross-with-contexts" {
   inherits = ["go-cross"]
   contexts = {

--- a/test/docker-bake.hcl
+++ b/test/docker-bake.hcl
@@ -38,7 +38,7 @@ target "hello-cross" {
   platforms = ["linux/amd64", "linux/arm64"]
 }
 
-target "secret" {
+target "foosec" {
   dockerfile = "secret.Dockerfile"
   secret = [
     "id=fixture_plain,env=FIXTURE_PLAIN",

--- a/test/docker-bake.hcl
+++ b/test/docker-bake.hcl
@@ -15,12 +15,34 @@ variable "XX_VERSION" {
   default = null
 }
 
+variable "BUILDX_VERSION" {
+  default = "not-leaked"
+}
+
+variable "GITHUB_SHA" {
+  default = ""
+}
+
+variable "RUNNER_OS" {
+  default = ""
+}
+
 target "go" {
   inherits = ["docker-metadata-action"]
   args = {
     XX_VERSION = XX_VERSION
   }
   dockerfile = "go.Dockerfile"
+}
+
+target "vars" {
+  args = {
+    BUILDX_VERSION = BUILDX_VERSION
+    GITHUB_SHA     = GITHUB_SHA
+    RUNNER_OS      = RUNNER_OS
+    XX_VERSION     = XX_VERSION
+  }
+  dockerfile = "vars.Dockerfile"
 }
 
 target "go-cross" {

--- a/test/secret.Dockerfile
+++ b/test/secret.Dockerfile
@@ -1,0 +1,11 @@
+# syntax=docker/dockerfile:1
+
+FROM alpine
+RUN --mount=type=secret,id=fixture_plain,env=fixture_plain \
+    --mount=type=secret,id=fixture_json,env=fixture_json \
+    printf 'fixture_plain=%s\n' "$fixture_plain" && \
+    printf 'fixture_json=%s\n' "$fixture_json" && \
+    printf 'alpha-line\nbeta-line\n' > /tmp/expected && \
+    printf '%s' "$fixture_plain" | cmp - /tmp/expected && \
+    printf 'gamma-line\ndelta-line\n' > /tmp/expected-json && \
+    printf '%s' "$fixture_json" | cmp - /tmp/expected-json

--- a/test/vars.Dockerfile
+++ b/test/vars.Dockerfile
@@ -1,0 +1,15 @@
+# syntax=docker/dockerfile:1
+
+FROM alpine
+ARG BUILDX_VERSION
+ARG GITHUB_SHA
+ARG RUNNER_OS
+ARG XX_VERSION
+RUN test "$BUILDX_VERSION" = "not-leaked"
+RUN test -n "$GITHUB_SHA"
+RUN test -n "$RUNNER_OS"
+RUN test "$XX_VERSION" = "1.9.0"
+RUN mkdir -p /out && printf 'ok\n' > /out/vars.txt
+
+FROM scratch
+COPY --from=0 /out /


### PR DESCRIPTION
needs #248 (see last commit)

This changes the Bake reusable workflow to pass caller-provided Bake variables through `docker/bake-action` as explicit vars instead of exporting them into the step environment. Bake environment variable lookup is disabled so workflow and runner env values do not accidentally override Bake variables, while `GITHUB_` and `RUNNER_` prefixed values are still forwarded explicitly for workflows that intentionally declare them.